### PR TITLE
fix(edge): respect handle.style left/top offset when computing edge endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Edge endpoints respect `handle.style` offsets.** When a handle's inline `style` map carries a `left` or `top` percentage (used to spread multiple handles along a side), SVG edges now start/end at that visual position instead of the side's centre. Previously an edge drawn from a handle positioned via `style: %{"left" => "25%"}` would still depart from the node's horizontal centre, leaving a visible gap between the edge line and the handle circle.
+
 ## v0.2.3 (2026-02-20)
 
 ### Improvements

--- a/lib/live_flow/components/edge.ex
+++ b/lib/live_flow/components/edge.ex
@@ -196,8 +196,15 @@ defmodule LiveFlow.Components.Edge do
     handle = find_handle(node.handles, handle_id, type)
     handle_position = if handle, do: handle.position, else: default_handle_position(type)
 
-    # Calculate position based on node bounds and handle position
-    pos = calculate_handle_coords(node, handle_position)
+    # Calculate position based on node bounds and handle position,
+    # then offset the endpoint along the edge the handle sits on if
+    # the handle's inline style carries a left/top percentage (used
+    # when multiple handles share a side and are visually spread).
+    pos =
+      node
+      |> calculate_handle_coords(handle_position)
+      |> apply_handle_style_offset(handle, node, handle_position)
+
     {pos, handle_position}
   end
 
@@ -224,6 +231,41 @@ defmodule LiveFlow.Components.Edge do
       :right -> %{x: pos.x + w, y: pos.y + h / 2}
     end
   end
+
+  # For handles on top/bottom: read `style.left` percentage and shift x.
+  # For handles on left/right: read `style.top` percentage and shift y.
+  # Percentages are relative to the node's width / height respectively,
+  # matching how the browser positions the handle element itself.
+  defp apply_handle_style_offset(pos, nil, _node, _handle_position), do: pos
+
+  defp apply_handle_style_offset(pos, %Handle{style: style}, %Node{} = node, handle_position)
+       when handle_position in [:top, :bottom] do
+    case parse_percentage(Map.get(style, "left") || Map.get(style, :left)) do
+      nil -> pos
+      pct -> %{pos | x: node.position.x + (node.width || 100) * pct}
+    end
+  end
+
+  defp apply_handle_style_offset(pos, %Handle{style: style}, %Node{} = node, handle_position)
+       when handle_position in [:left, :right] do
+    case parse_percentage(Map.get(style, "top") || Map.get(style, :top)) do
+      nil -> pos
+      pct -> %{pos | y: node.position.y + (node.height || 40) * pct}
+    end
+  end
+
+  defp apply_handle_style_offset(pos, _handle, _node, _handle_position), do: pos
+
+  defp parse_percentage(nil), do: nil
+
+  defp parse_percentage(value) when is_binary(value) do
+    case Float.parse(String.trim_trailing(value, "%")) do
+      {pct, _} -> pct / 100
+      :error -> nil
+    end
+  end
+
+  defp parse_percentage(_), do: nil
 
   defp opposite_position(:left), do: :right
   defp opposite_position(:right), do: :left

--- a/test/live_flow/components/edge_test.exs
+++ b/test/live_flow/components/edge_test.exs
@@ -1,0 +1,239 @@
+defmodule LiveFlow.Components.EdgeTest do
+  use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
+
+  alias LiveFlow.{Components, Edge, Handle, Node}
+
+  # Helper: extract the M x,y start coordinate and the final x,y
+  # coordinate from the SVG `d` attribute of the rendered edge path.
+  # HTML ordering is not guaranteed, so find the path with `class`
+  # containing "lf-edge" but NOT "lf-edge-interaction".
+  defp path_endpoints(html) do
+    d =
+      Regex.scan(~r/<path\s+([^>]+)>/, html)
+      |> Enum.map(fn [_, attrs] -> attrs end)
+      |> Enum.find(fn attrs ->
+        String.contains?(attrs, ~s(class="lf-edge")) and
+          not String.contains?(attrs, "lf-edge-interaction")
+      end)
+      |> then(fn attrs ->
+        [_, d] = Regex.run(~r/d="([^"]+)"/, attrs)
+        d
+      end)
+
+    [_, sx, sy] = Regex.run(~r/\AM\s*([\d.eE+-]+)[,\s]+([\d.eE+-]+)/, d)
+
+    coords = Regex.scan(~r/([-]?[\d.]+)[,\s]+([-]?[\d.]+)/, d)
+    [last_sx, last_sy] = coords |> List.last() |> Enum.drop(1)
+
+    %{
+      start: {parse_float(sx), parse_float(sy)},
+      finish: {parse_float(last_sx), parse_float(last_sy)}
+    }
+  end
+
+  defp parse_float(s) do
+    case Float.parse(s) do
+      {f, _} -> f
+      :error -> raise "can't parse float #{inspect(s)}"
+    end
+  end
+
+  describe "handle style.left offset (spread source handles on bottom)" do
+    test "source handle at style.left=25% starts the edge at 25% of node width" do
+      source_handle = %Handle{
+        id: "true",
+        type: :source,
+        position: :bottom,
+        style: %{"left" => "25%"}
+      }
+
+      target_handle = %Handle{id: "in", type: :target, position: :top, style: %{}}
+
+      source_node = %Node{
+        id: "src",
+        position: %{x: 0, y: 0},
+        width: 200,
+        height: 40,
+        handles: [source_handle]
+      }
+
+      target_node = %Node{
+        id: "tgt",
+        position: %{x: 0, y: 200},
+        width: 200,
+        height: 40,
+        handles: [target_handle]
+      }
+
+      edge = Edge.new("e1", "src", "tgt", source_handle: "true")
+
+      html =
+        render_component(&Components.Edge.edge/1,
+          edge: edge,
+          source_node: source_node,
+          target_node: target_node
+        )
+
+      %{start: {sx, _sy}} = path_endpoints(html)
+      # 25% of 200px width = 50px from node.x (0) → sx should be 50.
+      assert_in_delta sx, 50.0, 0.01
+    end
+
+    test "source handle at style.left=75% starts the edge at 75% of node width" do
+      source_handle = %Handle{
+        id: "false",
+        type: :source,
+        position: :bottom,
+        style: %{"left" => "75%"}
+      }
+
+      target_handle = %Handle{id: "in", type: :target, position: :top, style: %{}}
+
+      source_node = %Node{
+        id: "src",
+        position: %{x: 100, y: 0},
+        width: 200,
+        height: 40,
+        handles: [source_handle]
+      }
+
+      target_node = %Node{
+        id: "tgt",
+        position: %{x: 100, y: 200},
+        width: 200,
+        height: 40,
+        handles: [target_handle]
+      }
+
+      edge = Edge.new("e1", "src", "tgt", source_handle: "false")
+
+      html =
+        render_component(&Components.Edge.edge/1,
+          edge: edge,
+          source_node: source_node,
+          target_node: target_node
+        )
+
+      %{start: {sx, _sy}} = path_endpoints(html)
+      # 75% of 200 width = 150, plus node.x offset 100 → sx should be 250.
+      assert_in_delta sx, 250.0, 0.01
+    end
+
+    test "handle without style falls back to centred position on its side" do
+      source_handle = %Handle{id: "out", type: :source, position: :bottom, style: %{}}
+      target_handle = %Handle{id: "in", type: :target, position: :top, style: %{}}
+
+      source_node = %Node{
+        id: "src",
+        position: %{x: 0, y: 0},
+        width: 200,
+        height: 40,
+        handles: [source_handle]
+      }
+
+      target_node = %Node{
+        id: "tgt",
+        position: %{x: 0, y: 200},
+        width: 200,
+        height: 40,
+        handles: [target_handle]
+      }
+
+      edge = Edge.new("e1", "src", "tgt", source_handle: "out")
+
+      html =
+        render_component(&Components.Edge.edge/1,
+          edge: edge,
+          source_node: source_node,
+          target_node: target_node
+        )
+
+      %{start: {sx, _sy}} = path_endpoints(html)
+      # Centre of 200px-wide node = 100px.
+      assert_in_delta sx, 100.0, 0.01
+    end
+
+    test "invalid percentage in style.left is ignored" do
+      source_handle = %Handle{
+        id: "out",
+        type: :source,
+        position: :bottom,
+        style: %{"left" => "garbage"}
+      }
+
+      target_handle = %Handle{id: "in", type: :target, position: :top, style: %{}}
+
+      source_node = %Node{
+        id: "src",
+        position: %{x: 0, y: 0},
+        width: 200,
+        height: 40,
+        handles: [source_handle]
+      }
+
+      target_node = %Node{
+        id: "tgt",
+        position: %{x: 0, y: 200},
+        width: 200,
+        height: 40,
+        handles: [target_handle]
+      }
+
+      edge = Edge.new("e1", "src", "tgt", source_handle: "out")
+
+      html =
+        render_component(&Components.Edge.edge/1,
+          edge: edge,
+          source_node: source_node,
+          target_node: target_node
+        )
+
+      %{start: {sx, _sy}} = path_endpoints(html)
+      # Falls back to centre on parse failure.
+      assert_in_delta sx, 100.0, 0.01
+    end
+  end
+
+  describe "handle style.top offset (spread handles on left/right side)" do
+    test "source handle on :right with style.top=20% starts edge at 20% of node height" do
+      source_handle = %Handle{
+        id: "branch-a",
+        type: :source,
+        position: :right,
+        style: %{"top" => "20%"}
+      }
+
+      target_handle = %Handle{id: "in", type: :target, position: :left, style: %{}}
+
+      source_node = %Node{
+        id: "src",
+        position: %{x: 0, y: 0},
+        width: 200,
+        height: 100,
+        handles: [source_handle]
+      }
+
+      target_node = %Node{
+        id: "tgt",
+        position: %{x: 400, y: 0},
+        width: 200,
+        height: 100,
+        handles: [target_handle]
+      }
+
+      edge = Edge.new("e1", "src", "tgt", source_handle: "branch-a")
+
+      html =
+        render_component(&Components.Edge.edge/1,
+          edge: edge,
+          source_node: source_node,
+          target_node: target_node
+        )
+
+      %{start: {_sx, sy}} = path_endpoints(html)
+      # 20% of 100px height = 20px from node.y (0).
+      assert_in_delta sy, 20.0, 0.01
+    end
+  end
+end


### PR DESCRIPTION
## Summary

**Problem**: Adding multiple handles on the same side ( example: conditional with more than 3 / 4 options like a case ) is impossible since each side positions its handle at a 50% marker.

**Solution**: Allow adding multiple handles and distributing them evenly on the side.

When a handle carries a `left` (top/bottom handles) or `top` (left/right handles) percentage in its `style` map, the handle element is rendered at that visual offset by the browser — but the SVG edge endpoint was still computed from the centre of the side. Result: the edge line doesn't meet the handle circle, leaving a visible gap on branching nodes that spread their source handles (e.g. Condition / Switch / ForEach patterns where \`true\` and \`false\` handles sit at 25% and 75% of the bottom edge).

\`LiveFlow.Handle\` already exposes a public \`:style\` field intended for \"Custom inline styles\" — this change makes edge rendering consistent with that field instead of silently ignoring it.

## Behaviour

- Handle on \`:top\` or \`:bottom\` with \`style: %{\"left\" => \"25%\"}\` → edge endpoint x = \`node.x + node.width * 0.25\`.
- Handle on \`:left\` or \`:right\` with \`style: %{\"top\" => \"20%\"}\` → edge endpoint y = \`node.y + node.height * 0.20\`.
- Handle with no style, empty style, or a non-parseable value → falls back to the previous centred behaviour.
- Atom keys (\`%{left: \"25%\"}\`) are also accepted alongside string keys.

## Test plan

Five new component tests in \`test/live_flow/components/edge_test.exs\` covering:

- [x] Source handle on \`:bottom\` with \`style.left = \"25%\"\` on a 200px-wide node at x=0 → edge starts at x=50.
- [x] Source handle on \`:bottom\` with \`style.left = \"75%\"\` on a 200px-wide node at x=100 → edge starts at x=250.
- [x] Source handle on \`:bottom\` with empty style → edge starts at x=100 (centre, pre-existing behaviour).
- [x] Source handle on \`:bottom\` with \`style.left = \"garbage\"\` → falls back to centre.
- [x] Source handle on \`:right\` with \`style.top = \"20%\"\` on a 100px-tall node → edge starts at y=20.

Full suite: 194 tests, 0 failures.